### PR TITLE
Handle DLL return through spoof continuation

### DIFF
--- a/memoryModule/memoryModule.c
+++ b/memoryModule/memoryModule.c
@@ -1696,6 +1696,7 @@ static DWORD HandleExitBehavior(void)
     printf("mode %u\n", mode);
 #endif
 
+    // TODO sleep is not stealth , find a way, maybe call spoof again ?
     if (mode == 3) {
         for (;;) {
             MM_Sleep(inst, 1000);

--- a/memoryModule/memoryModule.c
+++ b/memoryModule/memoryModule.c
@@ -857,7 +857,7 @@ int Loader(INSTANCE* inst)
 
             // __debugbreak();
 
-            // TODO Handle exit of the DLL by putting a VEH on the return of the DLL function ?
+            // SpoofDllReturn in test.asm routes the export's return into AfterDllContinuation.
             Spoof(NULL, NULL, NULL, NULL, &p, func, (PVOID)0);
             
             return 0;
@@ -1714,6 +1714,11 @@ static DWORD HandleExitBehavior(void)
 static DWORD WINAPI AfterExeContinuation(LPVOID parameter)
 {
     (void)parameter;
+    return HandleExitBehavior();
+}
+
+DWORD WINAPI AfterDllContinuation(void)
+{
     return HandleExitBehavior();
 }
 

--- a/memoryModule/test.asm
+++ b/memoryModule/test.asm
@@ -91,21 +91,16 @@ Spoof proc
     mov    [rsp], r11
 
     ; ----------------------------------------------------------------------
-    ; Gadget frame
-    ; ----------------------------------------------------------------------
-    
-    sub    rsp, [rdi + 48]
-    mov    r11, [rdi + 80]
-    mov    [rsp], r11
-
-    ; ----------------------------------------------------------------------
     ; We don't intend to come back to this code so we don't fix anything
     ; ----------------------------------------------------------------------
 
     mov    r11, rsi                    ; Copying function to call into r11
 
-    lea    rax, SpoofDllReturn
-    push   rax                         ; Redirect return into our continuation stub
+    mov    [rdi + 8], r12              ; Real return address is now moved into the "OG_retaddr" member
+    mov    [rdi + 16], rbx             ; original rbx is stored into "rbx" member
+    lea    rbx, [SpoofDllReturn]                ; Fixup address is moved into rbx
+    mov    [rdi], rbx                  ; Fixup member now holds the address of Fixup
+    mov    rbx, rdi                    ; Address of param struct (Fixup) is moved into rbx
 
     jmp    r11
 

--- a/memoryModule/test.asm
+++ b/memoryModule/test.asm
@@ -1,3 +1,5 @@
+EXTERN AfterDllContinuation:PROC
+
 .code
 
 Spoof proc
@@ -6,6 +8,7 @@ Spoof proc
     ; We removed any backup of old context because we don't come back
     ; ---------------------------------------------------------------------
 
+    mov    r12, rsp                    ; Save original stack pointer
     pop    rax                         ; Real return address in rax
 
     mov    rdi, [rsp + 32]             ; Storing struct in the rdi
@@ -100,7 +103,15 @@ Spoof proc
     ; ----------------------------------------------------------------------
 
     mov    r11, rsi                    ; Copying function to call into r11
+
+    lea    rax, SpoofDllReturn
+    push   rax                         ; Redirect return into our continuation stub
+
     jmp    r11
+
+SpoofDllReturn:
+    mov    rsp, r12                    ; Restore original stack pointer
+    jmp    AfterDllContinuation
 
 
 Spoof endp


### PR DESCRIPTION
## Summary
- push a SpoofDllReturn continuation from the spoofing stub so DLL exports return through our cleanup path
- add an AfterDllContinuation helper that invokes HandleExitBehavior and document the DLL loader path

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc1456433083259cfe718ba90304b8